### PR TITLE
Allow AJAX Request And Security changes

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -8,7 +8,7 @@ class Plugin extends PluginBase
     {
         //add RouteCacheMiddleware as a global middleware to intercept all routes
         $this->app['Illuminate\Contracts\Http\Kernel']
-            ->pushMiddleware('SerenityNow\CacheRoute\Classes\RouteCacheMiddleware');
+             ->pushMiddleware('SerenityNow\CacheRoute\Classes\RouteCacheMiddleware');
     }
     
 }

--- a/classes/RouteCacheMiddleware.php
+++ b/classes/RouteCacheMiddleware.php
@@ -11,25 +11,48 @@ class RouteCacheMiddleware
     {
         //bail if table does not exist or
         //route not in the list of routes to be cached
-        if (!\Schema::hasTable('serenitynow_cacheroute_routes')||
-            !($cacheRow = $this->shouldBeCached($request))) {
+        $hasTable = \Schema::hasTable('serenitynow_cacheroute_routes');
+        $cacheRow = $this->shouldBeCached($request);
+        $ajaxRequest = $request->ajax();
+
+        if (!$hasTable || !$cacheRow || $ajaxRequest) {
             return $next($request);
         }
-        $cacheKey = $this->getCacheKey($request->url());
 
+        return $this->cacheResponse($next, $request, $cacheRow['cache_ttl']);
+    }
+
+    /**
+     * @param LaravelRequest $request
+     * @param Closure $next
+     * @param $ttl
+     * @return mixed
+     */
+    protected function cacheResponse(LaravelRequest $request, Closure $next, $ttl)
+    {
+        $cacheKey = $this->getCacheKey($request->url());
         if (\Cache::has($cacheKey)) {
             return \Response::make($this->getCachedContent($cacheKey, $request, \Cache::get($cacheKey)), 200);
         }
+
         $response = $next($request);
-        \Cache::put($cacheKey, $response->getContent(), $cacheRow['cache_ttl']);
+        \Cache::put($cacheKey, $response->getContent(), $ttl);
         return $response;
     }
 
-    //add instrumentation to help with debug. Adding ?debug
-    //to a cached url will precede the content with "CACHED"
+    /**
+     * add instrumentation to help with debug. Adding ?debug
+     * to a cached url will precede the content with "CACHED"
+     *
+     * @param $cacheKey
+     * @param $request
+     * @param $content
+     * @return string
+     */
     protected function getCachedContent($cacheKey, $request, $content)
     {
-        if ($request->exists('debug') || $request->exists('cache-info')) {
+        $isDebugRequest = $request->exists('debug') || $request->exists('cache-info');
+        if (\BackendAuth::check() && $isDebugRequest) {
             return $content.'
             <div class="cache-notice" style="display: block; position: fixed; width: 50%; background: #fff; padding: 20px 30px 25px; left: 50%; border: 1px solid #aaa; margin-left: calc(-50% / 2); bottom: 10%; z-index: 500; box-shadow: 0 0 20px rgba(0,0,0,0.2); font-size: 16px; font-size: 1.6rem;">
                 <div class="title" style="margin: -20px -30px 10px; background: #999; color: #fff; padding: 10px 30px; text-align: center;">CACHED CONTENT</div>
@@ -46,28 +69,39 @@ class RouteCacheMiddleware
                 <a href="?cache-clear" class="alert alert-info" style="float: right; background: #1991d1; color: #fff; padding: 10px 15px; margin-top: 20px; text-decoration: none;">Clear this now</a>
             </div>';
         }
-        if ($request->exists('cache-clear')) {
+
+        if (\BackendAuth::check() && $request->exists('cache-clear')) {
             \Cache::forget($cacheKey);
             return \Redirect::to($request->url());
-
         }
+
         return $content;
     }
 
     //generate a cache key based on the url
+
+    /**
+     * @param $url
+     * @return string
+     */
     protected function getCacheKey($url)
     {
         return 'SerenityNow.Cacheroute.' . str_slug($url);
     }
 
+    /**
+     * @param $request
+     * @return bool
+     */
     protected function shouldBeCached($request)
     {
         $cacheRouteRows = \Cache::remember('SerenityNow.Cacheroute.AllCachedRoutes',
             \Config::get('cms.urlCacheTtl'),
             function () {
-                return CacheRoute::orderBy('sort_order')->get()->toArray();
+                return (array) CacheRoute::orderBy('sort_order')->get();
             }
         );
+
         foreach ($cacheRouteRows as $cacheRow) {
             if ($request->is($cacheRow['route_pattern'])) {
                 return $cacheRow;

--- a/controllers/CacheRoutes.php
+++ b/controllers/CacheRoutes.php
@@ -7,9 +7,11 @@ use Flash;
 
 class CacheRoutes extends Controller
 {
-    public $implement = ['Backend\Behaviors\ListController',
+    public $implement = [
+        'Backend\Behaviors\ListController',
         'Backend\Behaviors\FormController',
-        'Backend\Behaviors\ReorderController'];
+        'Backend\Behaviors\ReorderController'
+    ];
 
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
@@ -18,13 +20,23 @@ class CacheRoutes extends Controller
     public $requiredPermissions = [
         'serenitynow.cacheroute.manage_cacheroute'
     ];
-    public function onClear(){
-        Artisan::call('cache:clear');
-        Flash::success('ALL cached content cleared');
-    }
+
+    /**
+     * CacheRoutes constructor.
+     */
     public function __construct()
     {
         parent::__construct();
+
         BackendMenu::setContext('SerenityNow.Cacheroute', 'CacheRoute');
+    }
+
+    /**
+     *
+     */
+    public function onClear()
+    {
+        Artisan::call('cache:clear');
+        Flash::success('ALL cached content cleared');
     }
 }

--- a/models/CacheRoute.php
+++ b/models/CacheRoute.php
@@ -14,8 +14,8 @@ class CacheRoute extends Model
      * Validation
      */
     public $rules = [
-        'route_pattern'=>'required|unique:serenitynow_cacheroute_routes',
-        'cache_ttl'=>'integer',
+        'route_pattern' => 'required|unique:serenitynow_cacheroute_routes',
+        'cache_ttl'     => 'integer',
     ];
 
     /*


### PR DESCRIPTION
Good day!

I've been using your plugin for a long time, but one feature was always missing: the ability to cache pages with built-in ajax framework components.

I propose to fix this problem in the plugin. I provide corrections that I use for several months on my projects.

The plugin adds speed to the page's rendering, and now also knows how to cache pages using ajax components.

For a long time I encountered bad people who cleaned the cache manually, because cleaning the cache is similar to the bitrix router, as well as making fixes allowing to debug and reset the cache only by logging in under the administrator.

I hope my works will help the development of the plugin! I want to continue to develop it.


Changes:
1. Allow Ajax Request
2. Code Refactoring
3. Access Debug info and clear cache to route only Administration User