### PR TITLE
Only the first line of an update should be a comment

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -7,8 +7,6 @@
     - 'Updated table serenitynow_cacheroute_routes to have Sort_order - required for reorder'
     - builder_table_update_serenitynow_cacheroute_routes.php
 1.0.4:
-    - 'Remove sort_order field from create form'
-    - 'Set default sort order for list (sort_order asc)'
-    - 'add icon for reorder button'
-1.0.5:  
+    - 'Remove sort_order field from create form, set default sort order for list (sort_order asc) & add icon for reorder button'
+1.0.5:
     - 'Several updates to cache-debugging appearance and behavior by mrbohnke'


### PR DESCRIPTION
Only the first line of an update should be a comment, the other lines are considered migration files. Please refer to the [docs](https://octobercms.com/docs/plugin/updates). Right now when running `artisan october:up` your plugin generates errors.